### PR TITLE
skip . and .. in `--tree`

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -526,6 +526,7 @@ fn printTree(cmd: Command, writer: anytype) !void {
     var prefix_list: std.ArrayList(bool) = .{};
 
     for (cmd.entries, 0..) |entry, i| {
+        if (std.mem.eql(u8, entry.name, ".") or std.mem.eql(u8, entry.name, "..")) continue;
         const is_last = i == cmd.entries.len - 1;
 
         try drawTreePrefix(writer, prefix_list.items, is_last);


### PR DESCRIPTION
`lsr --tree --all` would try to go into `..` too. this fixes this issue while not breaking `lsr --tree --all ..`