### PR TITLE
Optionally colorize long output and file names

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ DISPLAY OPTIONS
   -A, --almost-all                 Like --all, but skips implicit "." and ".." directories
   -C, --columns                    Print the output in columns
       --color=WHEN                 When to use colors (always, auto, never)
+      --full-color                 Optionally colorize long output and file name
       --group-directories-first    Print all directories before printing regular files
       --hyperlinks=WHEN            When to use OSC 8 hyperlinks (always, auto, never)
       --icons=WHEN                 When to display icons (always, auto, never)

--- a/src/main.zig
+++ b/src/main.zig
@@ -53,6 +53,8 @@ pub const Options = struct {
     winsize: ?posix.winsize = null,
     colors: Colors = .none,
 
+    pub const full_color: bool = false;
+
     const When = enum {
         never,
         auto,
@@ -212,6 +214,11 @@ pub fn main() !void {
                 } else if (eql(opt, "color")) {
                     cmd.opts.color = std.meta.stringToEnum(Options.When, val) orelse {
                         try stderr.print("Invalid color option: '{s}'\n", .{val});
+                        std.process.exit(1);
+                    };
+                } else if (eql(opt, "full-color")) {
+                    cmd.opts.all = parseArgBool(val) orelse {
+                        try stderr.print("Invalid boolean: '{s}'\n", .{val});
                         std.process.exit(1);
                     };
                 } else if (eql(opt, "human-readable")) {
@@ -464,6 +471,10 @@ fn printShortEntry(entry: Entry, cmd: Command, writer: anytype) !void {
         else => {
             if (entry.isExecutable()) {
                 try writer.writeAll(colors.executable);
+            // } else if (Options.full_color == true) {
+            } else if (true) {
+                const icon = Icon.get(entry);
+                try writer.writeAll(icon.color);
             }
         },
     }
@@ -625,6 +636,10 @@ fn printTreeEntry(entry: Entry, cmd: Command, writer: anytype, dir_path: [:0]con
         try writer.writeAll("\x1b]8;;\x1b\\");
         try writer.writeAll(colors.reset);
     } else {
+        if (Options.full_color == true) {
+            const icon = Icon.get(entry);
+            try writer.writeAll(icon.color);
+        }
         try writer.writeAll(entry.name);
         try writer.writeAll(colors.reset);
     }
@@ -745,6 +760,9 @@ fn printLong(cmd: *Command, writer: anytype) !void {
             else => {
                 if (entry.isExecutable()) {
                     try writer.writeAll(colors.executable);
+                } else if (Options.full_color == true) {
+                    const icon = Icon.get(entry);
+                    try writer.writeAll(icon.color);
                 }
             },
         }

--- a/src/main.zig
+++ b/src/main.zig
@@ -652,7 +652,6 @@ fn printLong(cmd: *Command, writer: anytype) !void {
     const now = zeit.instant(.{}) catch unreachable;
     const one_year_ago = try now.subtract(.{ .days = 365 });
     const colors = cmd.opts.colors;
-    const color_read_user_group = "\x1b[38;2;187;187;70m";
     const color_dash = "\x1b[38;2;80;80;80m";
 
     const longest_group, const longest_user, const longest_size, const longest_suffix = blk: {
@@ -735,7 +734,7 @@ fn printLong(cmd: *Command, writer: anytype) !void {
                         wrote_color = true;
                     },
                     'r' => {
-                        try writer.writeAll(color_read_user_group);
+                        try writer.writeAll(Options.Colors.yellow);
                         wrote_color = true;
                     },
                     'w' => {
@@ -759,7 +758,7 @@ fn printLong(cmd: *Command, writer: anytype) !void {
         }
         try writer.writeByte(' ');
         if (Options.full_color == true) {
-            try writer.writeAll(color_read_user_group);
+            try writer.writeAll(Options.Colors.yellow);
         }
         try writer.writeAll(user.name);
         var space_buf1 = [_][]const u8{" "};

--- a/src/main.zig
+++ b/src/main.zig
@@ -53,7 +53,7 @@ pub const Options = struct {
     winsize: ?posix.winsize = null,
     colors: Colors = .none,
 
-    pub const full_color: bool = false;
+    pub var full_color: bool = false;
 
     const When = enum {
         never,
@@ -217,7 +217,7 @@ pub fn main() !void {
                         std.process.exit(1);
                     };
                 } else if (eql(opt, "full-color")) {
-                    cmd.opts.all = parseArgBool(val) orelse {
+                    Options.full_color = parseArgBool(val) orelse {
                         try stderr.print("Invalid boolean: '{s}'\n", .{val});
                         std.process.exit(1);
                     };
@@ -471,8 +471,7 @@ fn printShortEntry(entry: Entry, cmd: Command, writer: anytype) !void {
         else => {
             if (entry.isExecutable()) {
                 try writer.writeAll(colors.executable);
-            // } else if (Options.full_color == true) {
-            } else if (true) {
+            } else if (Options.full_color == true) {
                 const icon = Icon.get(entry);
                 try writer.writeAll(icon.color);
             }
@@ -624,6 +623,9 @@ fn printTreeEntry(entry: Entry, cmd: Command, writer: anytype, dir_path: [:0]con
             if (stat_result) |stat| {
                 if (stat.mode & (std.posix.S.IXUSR | std.posix.S.IXGRP | std.posix.S.IXOTH) != 0) {
                     try writer.writeAll(colors.executable);
+                } else if (Options.full_color == true) {
+                    const icon = Icon.get(entry);
+                    try writer.writeAll(icon.color);
                 }
             }
         },
@@ -650,6 +652,8 @@ fn printLong(cmd: *Command, writer: anytype) !void {
     const now = zeit.instant(.{}) catch unreachable;
     const one_year_ago = try now.subtract(.{ .days = 365 });
     const colors = cmd.opts.colors;
+    const color_read_user_group = "\x1b[38;2;187;187;70m";
+    const color_dash = "\x1b[38;2;80;80;80m";
 
     const longest_group, const longest_user, const longest_size, const longest_suffix = blk: {
         var n_group: usize = 0;
@@ -705,8 +709,58 @@ fn printLong(cmd: *Command, writer: anytype) !void {
 
         const mode = entry.modeStr();
 
-        try writer.writeAll(&mode);
+        if (Options.full_color == true) {
+            var wrote_color: bool = false;
+            var symlink_mode_color: []const u8 = colors.symlink;
+            if (entry.kind == .sym_link) {
+                if (cmd.symlinks.get(entry.name)) |s| {
+                    if (s.exists) {
+                        symlink_mode_color = colors.symlink_target;
+                    } else {
+                        symlink_mode_color = colors.symlink_missing;
+                    }
+                } else {
+                    // fallback to regular symlink color (already defaulted)
+                    symlink_mode_color = colors.symlink;
+                }
+            }
+            for (mode) |c| {
+                switch (c) {
+                    'l' => {
+                        try writer.writeAll(symlink_mode_color);
+                        wrote_color = true;
+                    },
+                    'd' => {
+                        try writer.writeAll(colors.dir);
+                        wrote_color = true;
+                    },
+                    'r' => {
+                        try writer.writeAll(color_read_user_group);
+                        wrote_color = true;
+                    },
+                    'w' => {
+                        try writer.writeAll(Options.Colors.red);
+                        wrote_color = true;
+                    },
+                    'x' => {
+                        try writer.writeAll(Options.Colors.green);
+                        wrote_color = true;
+                    },
+                    else => {
+                        try writer.writeAll(color_dash);
+                        wrote_color = true;
+                    },
+                }
+                try writer.writeByte(c);
+                if (wrote_color) try writer.writeAll(colors.reset);
+            }
+        } else {
+            try writer.writeAll(&mode);
+        }
         try writer.writeByte(' ');
+        if (Options.full_color == true) {
+            try writer.writeAll(color_read_user_group);
+        }
         try writer.writeAll(user.name);
         var space_buf1 = [_][]const u8{" "};
         try writer.writeSplatAll(&space_buf1, longest_user - user.name.len);
@@ -715,11 +769,15 @@ fn printLong(cmd: *Command, writer: anytype) !void {
         var space_buf2 = [_][]const u8{" "};
         try writer.writeSplatAll(&space_buf2, longest_group - group.name.len);
         try writer.writeByte(' ');
+        try writer.writeAll(colors.reset);
 
         var size_buf: [16]u8 = undefined;
         const size = try entry.humanReadableSize(&size_buf);
         const suffix = entry.humanReadableSuffix();
 
+        if (Options.full_color == true) {
+            try writer.writeAll(Options.Colors.green);
+        }
         var space_buf3 = [_][]const u8{" "};
         try writer.writeSplatAll(&space_buf3, longest_size - size.len);
         try writer.writeAll(size);
@@ -728,7 +786,11 @@ fn printLong(cmd: *Command, writer: anytype) !void {
         var space_buf4 = [_][]const u8{" "};
         try writer.writeSplatAll(&space_buf4, longest_suffix - suffix.len);
         try writer.writeByte(' ');
+        try writer.writeAll(colors.reset);
 
+        if (Options.full_color == true) {
+            try writer.writeAll(Options.Colors.blue);
+        }
         try writer.print("{d: >2} {s} ", .{
             time.day,
             time.month.shortName(),
@@ -739,6 +801,7 @@ fn printLong(cmd: *Command, writer: anytype) !void {
         } else {
             try writer.print("{d: >5} ", .{@as(u32, @intCast(time.year))});
         }
+        try writer.writeAll(colors.reset);
 
         if (cmd.opts.useIcons()) {
             const icon = Icon.get(entry);


### PR DESCRIPTION
As the title says, allow the user to optionally colorize the long output and file name (the latter matching the color of the icon). This is made available via a new command line option: `--full-color`.